### PR TITLE
Horizon fixes

### DIFF
--- a/horizon.html
+++ b/horizon.html
@@ -284,10 +284,10 @@
 
         <!-- Keep Radiants in the Commonwealth - Horizon Patch -->
         <div class="section">
-            <h2 id="kric"><a class="link" href="https://www.nexusmods.com/fallout4/mods/54859" target="_blank">Keep Radiants in the Commonwealth - Horizon Patch</h2></a>
+            <h2 id="kric"><a class="link" href="https://www.nexusmods.com/fallout4/mods/46958" target="_blank">Keep Radiants in the Commonwealth - Horizon Patch</h2></a>
             <h2 class="install">Installation instructions:</h2>
             <ul>
-                <li><b>Main Files - Keep Radiants in the Commonwealth</b></li>
+                <li><b>Main Files - Keep Radiants in the Commonwealth UFO4P Version - Horizon Patch</b></li>
             </ul>
             <p>Fixes conflicts between Keep Radiants in the Commonwealth and Horizon's Enhanced Settlements Addon.</p>
         </div>
@@ -316,6 +316,16 @@
         <div class="section">
             <h2 id="clothingScrap">Clothing Scrapping Redone</h2>
             <h2 class="install">Instructions:</h2>
+            <ul>
+                <li>Disable the mod</li>
+            </ul>
+            <p>Not compatible.</p>
+        </div>
+
+        <!-- Remove Ammo from Dropped Guns -->
+        <div class="section">
+            <h2 id="dropAmmo">Remove Ammo from Dropped Guns</h2>
+            <h2 class="install">Installation instructions:</h2>
             <ul>
                 <li>Disable the mod</li>
             </ul>


### PR DESCRIPTION
Fixed KRIC patch link and added instructions on Remove Ammo from Dropped Guns